### PR TITLE
Update Dockerfiles with new npm setup-cpp version

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,13 @@ Here is an example for using setup-cpp to make a builder image that has the Cpp 
 FROM ubuntu:22.04 AS base
 
 # add setup-cpp
-WORKDIR "/"
-RUN apt-get update -qq
-RUN apt-get install -y --no-install-recommends wget
-RUN wget --no-verbose "https://github.com/aminya/setup-cpp/releases/download/v0.26.1/setup-cpp-x64-linux"
-RUN chmod +x ./setup-cpp-x64-linux
+RUN apt-get update && apt-get install -y \
+  npm \
+  && rm -rf /var/lib/apt/lists/*
+RUN npm install -g setup-cpp
 
 # install llvm, cmake, ninja, and ccache
-RUN ./setup-cpp-x64-linux --compiler llvm --cmake true --ninja true --ccache true --vcpkg true --make true
+RUN setup-cpp --compiler llvm --cmake true --ninja true --ccache true --vcpkg true --make true
 
 CMD source ~/.cpprc
 ENTRYPOINT [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -162,9 +162,8 @@ Here is an example for using setup-cpp to make a builder image that has the Cpp 
 FROM ubuntu:22.04 AS base
 
 # add setup-cpp
-RUN apt-get update && apt-get install -y \
-  npm \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq
+RUN apt-get install -y --no-install-recommends npm
 RUN npm install -g setup-cpp
 
 # install llvm, cmake, ninja, and ccache

--- a/dev/docker/arch_node.dockerfile
+++ b/dev/docker/arch_node.dockerfile
@@ -17,23 +17,21 @@ WORKDIR "/"
 # run installation
 RUN node ./setup-cpp.js --compiler llvm --cmake true --ninja true --cppcheck true --ccache true --vcpkg true --doxygen true --gcovr true --task true
 
-# clean up
-RUN pacman -Scc --noconfirm
-RUN rm -rf /tmp/*
+CMD ["source", "~/.cpprc"]
+ENTRYPOINT ["/bin/bash"]
 
-CMD source ~/.cpprc
-ENTRYPOINT [ "/bin/bash" ]
 
 #### Building
-FROM base AS builder
+FROM base as builder
 COPY ./dev/cpp_vcpkg_project /home/app
 WORKDIR /home/app
 RUN bash -c 'source ~/.cpprc \
     && task build'
 
+
 ### Running environment
 # use a distroless image or ubuntu:22.04 if you wish
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc as runner
 # copy the built binaries and their runtime dependencies
 COPY --from=builder /home/app/build/my_exe/Release/ /home/app/
 WORKDIR /home/app/

--- a/dev/docker/fedora_node.dockerfile
+++ b/dev/docker/fedora_node.dockerfile
@@ -1,11 +1,8 @@
 ## base image
 FROM fedora as base
 
-# nodejs
-RUN dnf -y install nodejs
-
-# curl for downloading setup-cpp
-RUN dnf -y install curl
+# nodejs and curl for downloading setup-cpp
+RUN dnf -y install nodejs curl
 
 # add setup-cpp.js
 COPY "./dist/node12" "/"
@@ -14,22 +11,21 @@ WORKDIR "/"
 # run installation
 RUN node ./setup-cpp.js --compiler llvm --cmake true --ninja true --cppcheck true --ccache true --vcpkg true --doxygen true --gcovr true --task true --powershell true
 
-# clean up
-RUN rm -rf /tmp/*
-
-CMD source ~/.cpprc
+CMD ["source", "~/.cpprc"]
 ENTRYPOINT [ "/bin/bash" ]
 
+
 #### Building
-FROM base AS builder
+FROM base as builder
 COPY ./dev/cpp_vcpkg_project /home/app
 WORKDIR /home/app
 RUN bash -c 'source ~/.cpprc \
     && task build'
 
+
 ### Running environment
 # use a distroless image or ubuntu:22.04 if you wish
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc as runner
 # copy the built binaries and their runtime dependencies
 COPY --from=builder /home/app/build/my_exe/Release/ /home/app/
 WORKDIR /home/app/

--- a/dev/docker/ubuntu.dockerfile
+++ b/dev/docker/ubuntu.dockerfile
@@ -1,15 +1,14 @@
 #### Base Image
 FROM ubuntu:22.04 AS base
 
-# add setup-cpp
-WORKDIR "/"
-RUN apt-get update -qq
-RUN apt-get install -y --no-install-recommends wget
-RUN wget --no-verbose "https://github.com/aminya/setup-cpp/releases/download/v0.26.1/setup-cpp-x64-linux"
-RUN chmod +x ./setup-cpp-x64-linux
+# install setup-cpp
+RUN apt-get update && apt-get install -y \
+  npm \
+  && rm -rf /var/lib/apt/lists/*
+RUN npm install -g setup-cpp
 
 # install llvm, cmake, ninja, and ccache
-RUN ./setup-cpp-x64-linux --compiler llvm --cmake true --ninja true --ccache true --vcpkg true --task true
+RUN setup-cpp --compiler llvm --cmake true --ninja true --ccache true --vcpkg true --task true
 
 CMD source ~/.cpprc
 ENTRYPOINT [ "/bin/bash" ]

--- a/dev/docker/ubuntu.dockerfile
+++ b/dev/docker/ubuntu.dockerfile
@@ -1,28 +1,29 @@
 #### Base Image
-FROM ubuntu:22.04 AS base
+FROM ubuntu:22.04 as base
 
 # install setup-cpp
-RUN apt-get update && apt-get install -y \
-  npm \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq
+RUN apt-get install -y --no-install-recommends npm
 RUN npm install -g setup-cpp
 
 # install llvm, cmake, ninja, and ccache
 RUN setup-cpp --compiler llvm --cmake true --ninja true --ccache true --vcpkg true --task true
 
-CMD source ~/.cpprc
-ENTRYPOINT [ "/bin/bash" ]
+CMD ["source", "~/.cpprc"]
+ENTRYPOINT ["/bin/bash"]
+
 
 #### Building
-FROM base AS builder
-ADD ./dev/cpp_vcpkg_project /home/app
+FROM base as builder
+COPY ./dev/cpp_vcpkg_project /home/app
 WORKDIR /home/app
 RUN bash -c 'source ~/.cpprc \
     && task build'
 
+
 ### Running environment
 # use a distroless image or ubuntu:22.04 if you wish
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc as runner
 # copy the built binaries and their runtime dependencies
 COPY --from=builder /home/app/build/my_exe/Release/ /home/app/
 WORKDIR /home/app/

--- a/dev/docker/ubuntu_20.04_node.dockerfile
+++ b/dev/docker/ubuntu_20.04_node.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 AS base
+FROM ubuntu:20.04 as base
 
 # set time-zone
 ENV TZ=Canada/Pacific
@@ -8,7 +8,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq
 RUN apt-get install -y --no-install-recommends curl gnupg ca-certificates
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+RUN ["/bin/bash", "-c", "set -o pipefail && curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -"]
 RUN apt-get install -y --no-install-recommends nodejs
 
 # add setup-cpp.js
@@ -18,19 +18,21 @@ WORKDIR "/"
 # run installation
 RUN node ./setup-cpp.js --compiler llvm --cmake true --ninja true --cppcheck true --ccache true --vcpkg true --doxygen true --gcovr true --task true
 
-CMD source ~/.cpprc
-ENTRYPOINT [ "/bin/bash" ]
+CMD ["source", "~/.cpprc"]
+ENTRYPOINT ["/bin/bash"]
+
 
 #### Building
-FROM base AS builder
-ADD ./dev/cpp_vcpkg_project /home/app
+FROM base as builder
+COPY ./dev/cpp_vcpkg_project /home/app
 WORKDIR /home/app
 RUN bash -c 'source ~/.cpprc \
     && task build'
 
+
 ### Running environment
 # use a distroless image or ubuntu:20.04 if you wish
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc as runner
 # copy the built binaries and their runtime dependencies
 COPY --from=builder /home/app/build/my_exe/Release/ /home/app/
 WORKDIR /home/app/

--- a/dev/docker/ubuntu_node.dockerfile
+++ b/dev/docker/ubuntu_node.dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:22.04 AS base
 
-RUN apt-get update && apt-get install -y \
-  nodejs \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -qq 
+RUN apt-get install -y --no-install-recommends nodejs
 
 # add setup-cpp.js
 COPY "./dist/node12" "/"
@@ -11,12 +10,9 @@ WORKDIR "/"
 # run installation
 RUN node ./setup-cpp.js --compiler llvm --cmake true --ninja true --cppcheck true --ccache true --vcpkg true --doxygen true --gcovr true --task true --powershell true
 
-# clean up
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN rm -rf /tmp/*
-
-CMD source ~/.cpprc
+CMD ["source", "~/.cpprc"]
 ENTRYPOINT [ "/bin/bash" ]
+
 
 #### Building
 FROM base AS builder
@@ -25,10 +21,11 @@ WORKDIR /home/app
 RUN bash -c 'source ~/.cpprc \
     && task build'
 
+
 ### Running environment
 # use a distroless image or ubuntu:22.04 if you wish
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc as runner
 # copy the built binaries and their runtime dependencies
 COPY --from=builder /home/app/build/my_exe/Release/ /home/app/
 WORKDIR /home/app/
-ENTRYPOINT ["./my_exe"]
+ENTRYPOINT ["./my_exe"]s

--- a/dev/docker/ubuntu_node.dockerfile
+++ b/dev/docker/ubuntu_node.dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:22.04 AS base
 
-RUN apt-get update -qq
-RUN apt-get install -y --no-install-recommends nodejs
+RUN apt-get update && apt-get install -y \
+  nodejs \
+  && rm -rf /var/lib/apt/lists/*
 
 # add setup-cpp.js
 COPY "./dist/node12" "/"

--- a/dev/docker/ubuntu_node.dockerfile
+++ b/dev/docker/ubuntu_node.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04 AS base
 
-RUN apt-get update -qq 
+RUN apt-get update -qq
 RUN apt-get install -y --no-install-recommends nodejs
 
 # add setup-cpp.js
@@ -28,4 +28,4 @@ FROM gcr.io/distroless/cc as runner
 # copy the built binaries and their runtime dependencies
 COPY --from=builder /home/app/build/my_exe/Release/ /home/app/
 WORKDIR /home/app/
-ENTRYPOINT ["./my_exe"]s
+ENTRYPOINT ["./my_exe"]


### PR DESCRIPTION
I'm updating setup-cpp in the docker files with the new [npm version](https://www.npmjs.com/package/setup-cpp)...
While the other error `'ci-log@1.0.0' is not in this registry.` is fixed in [v0.26.1](https://github.com/aminya/setup-cpp/releases/tag/v0.26.1).
It seems like the docker build didn't work, yet...

```bash
docker build -f ./dev/docker/ubuntu.dockerfile --target base -t setup-cpp:base .
```

```bash
Step 3/6 : RUN npm install -g setup-cpp
 ---> Using cache
 ---> b100e31669b4
Step 4/6 : RUN setup-cpp --compiler llvm --cmake true --ninja true --ccache true --vcpkg true --task true
 ---> Running in 6ac6b470633c
/usr/local/bin/setup-cpp: 1: Syntax error: "(" unexpected
The command '/bin/sh -c setup-cpp --compiler llvm --cmake true --ninja true --ccache true --vcpkg true --task true' returned a non-zero code: 2  
```


@aminya You may also want to update the README
> ### Inside Docker inside GitHub Actions
>
> ...
> 
>        id: docker_build
>        run: |
>          docker build -f ./dev/docker/debian.dockerfile -t setup-cpp .
Seems to be outdated, I think it's `./dev/docker/ubuntu.dockerfile` now.

> ### Inside GitLab pipelines
> .setup-cpp: &setup-cpp |
>  curl -LJO "https://github.com/aminya/setup-cpp/releases/download/v0.26.1/setup-cpp-x64-linux"
>  chmod +x setup-cpp-x64-linux
>  ./setup-cpp-x64-linux --compiler $compiler --cmake true --ninja true --ccache true --vcpkg true
>  source ~/.cpprc

> ### Inside Docker
>
> Here is an example for using setup-cpp to make a builder image that has the Cpp tools you need.

I would recommend using [ADD](https://docs.docker.com/engine/reference/builder/#add) instead of `wget`. (you can also use a checksum for sure)
```dockerfile
ARG setup_cpp_version="0.26.1"
ADD https://github.com/aminya/setup-cpp/releases/download/v${setup_cpp_version}/setup-cpp-x64-linux 
RUN chmod +x ./setup-cpp-x64-linux
# install llvm, cmake, ninja, and ccache
RUN ./setup-cpp-x64-linux --compiler llvm --cmake true --ninja true --ccache true --vcpkg true --make true
```

Or use the npm version (to be always up-to-date ?), like in the README/example:
```dockerfile
RUN apt-get update && apt-get install -y \
  npm \
  && rm -rf /var/lib/apt/lists/*
RUN npm install -g setup-cpp
# install llvm, cmake, ninja, and ccache
RUN setup-cpp --compiler llvm --cmake true --ninja true --ccache true --vcpkg true --make true
```

_(I think the image with the npm is a bit bigger (?), but the user has options and can deside)_