### PR TITLE
fix: use higher priority when installing llvm alternatives

### DIFF
--- a/src/gcc/gcc.ts
+++ b/src/gcc/gcc.ts
@@ -78,7 +78,7 @@ function getGccPackageInfo(version: string, platform: NodeJS.Platform, arch: str
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function setupGcc(version: string, setupDir: string, arch: string) {
+export async function setupGcc(version: string, setupDir: string, arch: string, priority: number = 40) {
   let installationInfo: InstallationInfo | undefined
   switch (process.platform) {
     case "win32": {
@@ -139,7 +139,7 @@ export async function setupGcc(version: string, setupDir: string, arch: string) 
     }
   }
   if (installationInfo !== undefined) {
-    await activateGcc(version, installationInfo.binDir)
+    await activateGcc(version, installationInfo.binDir, priority)
     return installationInfo
   }
   return undefined
@@ -199,7 +199,7 @@ async function setupChocoMingw(version: string, arch: string): Promise<Installat
   return undefined
 }
 
-async function activateGcc(version: string, binDir: string) {
+async function activateGcc(version: string, binDir: string, priority: number = 40) {
   const promises: Promise<void | ExecaReturnValue<string>>[] = []
   // Setup gcc as the compiler
 
@@ -223,10 +223,10 @@ async function activateGcc(version: string, binDir: string) {
 
       if (isUbuntu()) {
         promises.push(
-          updateAptAlternatives("cc", `${binDir}/gcc-${majorVersion}`),
-          updateAptAlternatives("cxx", `${binDir}/g++-${majorVersion}`),
-          updateAptAlternatives("gcc", `${binDir}/gcc-${majorVersion}`),
-          updateAptAlternatives("g++", `${binDir}/g++-${majorVersion}`),
+          updateAptAlternatives("cc", `${binDir}/gcc-${majorVersion}`, priority),
+          updateAptAlternatives("cxx", `${binDir}/g++-${majorVersion}`, priority),
+          updateAptAlternatives("gcc", `${binDir}/gcc-${majorVersion}`, priority),
+          updateAptAlternatives("g++", `${binDir}/g++-${majorVersion}`, priority),
         )
       }
     } else {
@@ -234,10 +234,10 @@ async function activateGcc(version: string, binDir: string) {
 
       if (isUbuntu()) {
         promises.push(
-          updateAptAlternatives("cc", `${binDir}/gcc-${version}`),
-          updateAptAlternatives("cxx", `${binDir}/g++-${version}`),
-          updateAptAlternatives("gcc", `${binDir}/gcc-${version}`),
-          updateAptAlternatives("g++", `${binDir}/g++-${version}`),
+          updateAptAlternatives("cc", `${binDir}/gcc-${version}`, priority),
+          updateAptAlternatives("cxx", `${binDir}/g++-${version}`, priority),
+          updateAptAlternatives("gcc", `${binDir}/gcc-${version}`, priority),
+          updateAptAlternatives("g++", `${binDir}/g++-${version}`, priority),
         )
       }
     }

--- a/src/llvm/llvm.ts
+++ b/src/llvm/llvm.ts
@@ -82,8 +82,9 @@ const llvmBinaryDeps = memoize(llvmBinaryDeps_raw, { isPromise: true })
 
 async function setupLLVMDeps_raw(arch: string) {
   if (process.platform === "linux") {
-    // using llvm requires ld, an up to date libstdc++, etc. So, install gcc first
-    await setupGcc(getVersion("gcc", undefined, await ubuntuVersion()), "", arch)
+    // using llvm requires ld, an up to date libstdc++, etc. So, install gcc first,
+    // but with a lower priority than the one used by activateLLVM()
+    await setupGcc(getVersion("gcc", undefined, await ubuntuVersion()), "", arch, 40)
   }
 }
 const setupLLVMDeps = memoize(setupLLVMDeps_raw, { isPromise: true })
@@ -125,9 +126,10 @@ export async function activateLLVM(directory: string) {
   // }
 
   if (isUbuntu()) {
+    const priority = 60
     actPromises.push(
-      updateAptAlternatives("cc", `${directory}/bin/clang`),
-      updateAptAlternatives("cxx", `${directory}/bin/clang++`),
+      updateAptAlternatives("cc", `${directory}/bin/clang`, priority),
+      updateAptAlternatives("cxx", `${directory}/bin/clang++`, priority),
       updateAptAlternatives("clang", `${directory}/bin/clang`),
       updateAptAlternatives("clang++", `${directory}/bin/clang++`),
       updateAptAlternatives("lld", `${directory}/bin/lld`),

--- a/src/utils/setup/setupAptPack.ts
+++ b/src/utils/setup/setupAptPack.ts
@@ -219,14 +219,14 @@ export async function addAptKeyViaDownload(name: string, url: string) {
   return fileName
 }
 
-export async function updateAptAlternatives(name: string, path: string) {
+export async function updateAptAlternatives(name: string, path: string, priority: number = 40) {
   if (GITHUB_ACTIONS) {
-    return execRoot("update-alternatives", ["--install", `/usr/bin/${name}`, name, path, "40"])
+    return execRoot("update-alternatives", ["--install", `/usr/bin/${name}`, name, path, priority.toString()])
   } else {
     await setupCppInProfile()
     return appendFile(
       cpprc_path,
-      `\nif [ $UID -eq 0 ]; then update-alternatives --install /usr/bin/${name} ${name} ${path} 40; fi\n`,
+      `\nif [ $UID -eq 0 ]; then update-alternatives --install /usr/bin/${name} ${name} ${path} ${priority}; fi\n`,
     )
   }
 }


### PR DESCRIPTION
before this change, gcc and g++ are installed using `updateAptAlternatives()` with the same priority of 40 when they are installed along with ld and libstdc++ as the dependencies of clang and llvm. but both gcc and clang are installed using the same priority of 40 on ubuntu, and the same applies to g++ and clang++. this renders it impossible to use the default compilers of cc and cxx when clang/llvm is installed using setup-cpp on an ubuntu host, as gcc is always prefered over clang by the update-alternatives, as their priorities are identical.

in this change, the "priority" parameter is added to the setupGcc(), so that we can specify a different priority when installing llvm. strictly speaking, this is not necessary. as we can just use a higher priority when calling updateAptAlternatives() in llvm/llvm.ts. but by making it more explicit, we can ensure that we always prefer llvm over gcc when installing llvm.